### PR TITLE
Added event for setInitArrow

### DIFF
--- a/Initiative Board.3c5226.ttslua
+++ b/Initiative Board.3c5226.ttslua
@@ -1200,6 +1200,12 @@ function setInitArrow(obj, color, turnOn)
   local objUI = obj.UI.getXmlTable()
   local guid = obj.getGUID()
   local arrowVisibility
+  
+  local callback = "dynamicInitiativeBoard_onSetInitArrow"
+  if obj.getVar(callback) ~= nil then
+    local preventDefault = obj.call(callback, turnOn)
+    if preventDefault == true then return end
+  end
 
   if hostHasInitiativeControl then arrowVisibility = "Black|Host|"..color
   else arrowVisibility = "Black|"..color


### PR DESCRIPTION
Added an event that allows objects to define custom behaviours for when they are highlighted by the initiative arrow


![Recording 2022-05-10 at 23 16 20](https://user-images.githubusercontent.com/59068049/167768096-84d62318-6b57-49a4-9f3e-fe239dfc3687.gif)

Objects can define the function `dynamicInitiativeBoard_onSetInitArrow` that will be called when the object's initiative arrow is set.
The function can return `true` to prevent the initiative arrow from being shown.

The listeners used in the gif example look like this:

**Pawn:**
```lua
function dynamicInitiativeBoard_onSetInitArrow(turnOn)
    if turnOn then
        self.setColorTint({255, 0, 0, 255})
    else
        self.setColorTint({255, 255, 255, 255})
    end
    return true
end
```

**RPG Figure:**
```lua
function dynamicInitiativeBoard_onSetInitArrow(turnOn)
    if turnOn then
        self.RPGFigurine.changeMode(1)
    else
        self.RPGFigurine.changeMode(0)
    end
end
```

**Asset Bundle:**
```lua
function dynamicInitiativeBoard_onSetInitArrow(turnOn)
    if turnOn then
        self.AssetBundle.playLoopingEffect(1)
    else
        self.AssetBundle.playLoopingEffect(0)
    end
    return true
end
```